### PR TITLE
Fix encoding

### DIFF
--- a/lib/SMS/Send/Tellustalk.pm
+++ b/lib/SMS/Send/Tellustalk.pm
@@ -28,7 +28,7 @@ sub send_sms {
 		sms_originator_source => "text",
 		sms_originator_text   => "$self->{_sender}"
 	};
-	my $response = _post($self, to_json($json_args));
+	my $response = _post($self, to_json($json_args, {utf8 => 1}));
 	if ($response->{status} eq "200") {
 		return 1;
 	}


### PR DESCRIPTION
I was having problems with text messages not getting sent (from Koha) because of encoding issues. Specifying {utf8 => 1} in the call to to_json fixed it.